### PR TITLE
Socint 121 tolerate webdriver creation exception

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,10 +10,10 @@ steps:
     args: ['xpzf', 'm2.tar.gz']
 
   - name: 'maven:3-jdk-11'
-    id: Maven Build
+    id: Maven Deploy
     env:
       - TZ=Europe/London
-    args: ['-Dmaven.repo.local=/workspace/.m2/repository', '-DskipTests', 'install']
+    args: ['-Dmaven.repo.local=/workspace/.m2/repository', 'deploy']
     entrypoint: mvn
       #
   # Update M2 repo cache

--- a/src/main/java/uk/gov/ons/ctp/common/util/WebDriverFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/common/util/WebDriverFactory.java
@@ -41,13 +41,18 @@ public class WebDriverFactory {
 
   public void closeWebDriver(WebDriver driver) {
     driversQuitting.incrementAndGet();
-    Thread t =
-        new Thread(
-            () -> {
-              driver.quit();
-              driversQuitting.decrementAndGet();
-            });
-    t.start();
+    if (usePool()) {
+      Thread t =
+          new Thread(
+              () -> {
+                driver.quit();
+                driversQuitting.decrementAndGet();
+              });
+      t.start();
+    } else {
+      driver.quit();
+      driversQuitting.decrementAndGet();
+    }
   }
 
   public WebDriver getWebDriver() {

--- a/src/main/java/uk/gov/ons/ctp/common/util/WebDriverFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/common/util/WebDriverFactory.java
@@ -108,6 +108,8 @@ public class WebDriverFactory {
     if (usePool()) {
       Thread cacheFillerThread = new Thread(this::fillPoolOfWebDrivers);
       cacheFillerThread.start();
+    } else {
+      log.info("Not using Pooled WebDrivers");
     }
   }
 


### PR DESCRIPTION
Modify WebDriverFactory to disable all pooling and threaded actions in the following cases:
- not using the pubsub emulator
- not headless
- single core

Code has been changed so that If the WebDriverFactory is in pooling mode, then the thread filling the pool will not hang if WebDriver Exceptions happens

This ensures that the concourse build does (slow) simple create / quit of selenium WebDriver , but local builds enjoy the speedups of the pooling code, as we did in Census.